### PR TITLE
Add rule for Ember.on usage

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -14,6 +14,7 @@ module.exports = {
     'ember-best-practices/no-action-cp': 2,
     'ember-best-practices/no-attrs': 2,
     'ember-best-practices/no-observers': 2,
-    'ember-best-practices/require-dependent-keys': 2
+    'ember-best-practices/require-dependent-keys': 2,
+    'ember-best-practices/no-lifecycle-events': 2
   }
 };

--- a/lib/rules/no-lifecycle-events.js
+++ b/lib/rules/no-lifecycle-events.js
@@ -1,0 +1,55 @@
+const MESSAGE = 'Do not use events for lifecycle hooks. Please use the actual hooks instead: https://github.com/chadhietala/ember-best-practices/blob/master/guides/rules/no-lifecycle-events.md';
+
+function isOn(node) {
+  return node.name === 'on';
+}
+
+function isEmber(node) {
+  return node.name === 'Ember';
+}
+
+module.exports = {
+  meta: {
+    message: MESSAGE
+  },
+  create(context) {
+    return {
+
+      ImportDeclaration(node) {
+        if (node.source.value === '@ember/object/evented') {
+          node.specifiers.forEach((specifier) => {
+            if (isOn(specifier.imported)) {
+              context.report(node, MESSAGE);
+            }
+          });
+        }
+      },
+
+      FunctionExpression(node) {
+        if (node.parent.property && isOn(node.parent.property)) {
+          context.report(node, MESSAGE);
+        }
+      },
+
+      MemberExpression(node) {
+        if (isEmber(node.object) && isOn(node.property)) {
+          context.report(node, MESSAGE);
+        }
+      },
+
+      CallExpression(node) {
+        if (isOn(node.callee)) {
+          context.getScope().variables.forEach((v) => {
+            if (isOn(v)) {
+              v.defs.forEach((defNode) => {
+                if (defNode.node.type === 'VariableDeclarator' && isEmber(defNode.node.init)) {
+                  context.report(node, MESSAGE);
+                }
+              });
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-lifecycle-events.js
+++ b/tests/lib/rules/no-lifecycle-events.js
@@ -1,0 +1,95 @@
+const rule = require('../../../lib/rules/no-lifecycle-events');
+const MESSAGE = rule.meta.message;
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-lifecycle-events', rule, {
+  valid: [
+    {
+      code: `
+        export default Ember.Component({
+          didInsertElement() {
+            this.$().on('focus', () => {
+              alert('sss');
+            });
+          }
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      }
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        export default Ember.Component({
+          registerFocus: Ember.on('didInsertElement', function() {
+            this.$().on('focus', () => {
+              alert('sss');
+            });
+          })
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        const { on } = Ember;
+        export default Ember.Component({
+          registerFocus: on('didInsertElement', function() {
+            this.$().on('focus', () => {
+              alert('sss');
+            });
+          })
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import { on } from '@ember/object/evented';
+        export default Ember.Component({
+          registerFocus: on('didInsertElement', function() {
+            this.$().on('focus', () => {
+              alert('sss');
+            });
+          })
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          registerFocus: function() {
+            this.$().on('focus', () => {
+              alert('sss');
+            });
+          }.on('didInsertElement')
+        });`,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+      },
+      errors: [{
+        message: MESSAGE
+      }]
+    }
+  ]
+});


### PR DESCRIPTION
This lints for all the ways you can use events to run some arbitrary
code. We want people to use the actual hooks.