### PR TITLE
[Bugfix] Cautiously path into AST nodes

### DIFF
--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -1,5 +1,7 @@
+const { get } = require('../utils/get');
+
 function hasAttrsSnapShot(node) {
-  let methodName = node.parent.key.name;
+  let methodName = get(node, 'parent.key.name');
   let hasParams = node.params.length > 0;
   return (methodName === 'didReceiveAttrs' || methodName === 'didUpdateAttrs') && hasParams;
 }

--- a/lib/rules/no-unguarded-document.js
+++ b/lib/rules/no-unguarded-document.js
@@ -1,9 +1,10 @@
 const { isGuarded } = require('../utils/fast-boot');
+const { get } = require('../utils/get');
 
 const MESSAGE = 'Do not use unguarded document references. Please see the following guide for more infromation: http://github.com/chadhietala/ember-best-practices/files/guides/no-unguarded-document.md';
 
 function isDocumentReference(node) {
-  return node.callee.object.name === 'document';
+  return get(node, 'callee.object.name') === 'document';
 }
 
 module.exports = {


### PR DESCRIPTION
These would fail in real code sense `parent` or `callee.object` can be `undefined`. I wrote a graceful `get()` function like ember has to deal with retrieving values in an object path. 