### PR TITLE
Fixing require-dependent-keys

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -16,8 +16,6 @@ module.exports = {
     'ember-best-practices/no-observers': 2,
     'ember-best-practices/require-dependent-keys': 2,
     'ember-best-practices/no-lifecycle-events': 2,
-    'ember-best-practices/no-timers': 2,
-    'ember-best-practices/no-unguarded-document': 2,
     'ember-best-practices/no-attrs-snapshot': 2
   }
 };

--- a/lib/rules/require-dependent-keys.js
+++ b/lib/rules/require-dependent-keys.js
@@ -3,6 +3,7 @@
  * @author Chad Hietala
  */
 
+const { get } = require('../utils/get');
 const MESSAGE = 'Do not use Computed Properties without dependent keys. Please see following guide for more information: https://github.com/chadhietala/ember-best-practices/blob/master/guides/rules/require-dependent-keys.md';
 
 function isMissingDependentKeys(name, node, context) {
@@ -23,7 +24,7 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        let name = node.callee.name || node.callee.property.name;
+        let name = get(node, 'callee.name') || get(node, 'callee.property.name');
         isMissingDependentKeys(name, node, context);
       }
     };


### PR DESCRIPTION
Fixing require-dependent-keys to use `get`. Removing BPR specific rules from recommended.