### PR TITLE
Fixing bug in np-side-effect-cp whereby the bindings are undefined

### DIFF
--- a/lib/rules/no-side-effect-cp.js
+++ b/lib/rules/no-side-effect-cp.js
@@ -23,7 +23,9 @@ module.exports = {
   },
   create(context) {
     let inCPGettter = false;
-    let bindings, emberImportBinding;
+    let bindings = [];
+    let emberImportBinding;
+
     return {
       ImportDeclaration(node) {
         bindings = collectImportBindings(node, {


### PR DESCRIPTION
A bug was manifesting where the `bindings` variable in `no-side-effect-cp` was undefined, in spite of its being set correctly within that context. Giving it a default value fixed it.

Unfortunately I couldn't detect a pattern that caused this to manifest itself. 