### PR TITLE
Fix: An addon must define a `name` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "author": "",
   "license": "MIT",
   "keywords": [
-    "ember",
-    "ember-addon",
     "eslint",
     "eslintplugin",
     "eslint-plugin"


### PR DESCRIPTION
Remove `ember` and `ember-addon` keywords since it is not an actual `ember-addon`.

I believe this would fix #38 