### PR TITLE
Do not throw errors for custom events (only lifecycle hooks)

### DIFF
--- a/lib/rules/no-lifecycle-events.js
+++ b/lib/rules/no-lifecycle-events.js
@@ -8,6 +8,23 @@ const { collectObjectPatternBindings } = require('../utils/destructed-binding');
 const { getEmberImportBinding } = require('../utils/imports');
 
 const MESSAGE = 'Do not use events for lifecycle hooks. Please use the actual hooks instead: https://github.com/chadhietala/ember-best-practices/blob/master/guides/rules/no-lifecycle-events.md';
+// TODO: Pull these from somewhere?
+const LIFECYCLE_HOOKS = [
+  'didDestroyElement',
+  'didInsertElement',
+  'didReceiveAttrs',
+  'didReceiveAttrs',
+  'didRender',
+  'didRender',
+  'didUpdate',
+  'didUpdateAttrs',
+  'init',
+  'willClearRender',
+  'willDestroyElement',
+  'willRender',
+  'willRender',
+  'willUpdate'
+];
 
 function isOn(node) {
   return node.name === 'on';
@@ -15,6 +32,10 @@ function isOn(node) {
 
 function isEmber(node) {
   return node.name === 'Ember';
+}
+
+function isLifecycleHook(argument) {
+  return LIFECYCLE_HOOKS.includes(argument.value);
 }
 
 module.exports = {
@@ -43,16 +64,6 @@ module.exports = {
         }
       },
 
-      ImportDeclaration(node) {
-        if (node.source.value === '@ember/object/evented') {
-          node.specifiers.forEach((specifier) => {
-            if (isOn(specifier.imported)) {
-              context.report(node, MESSAGE);
-            }
-          });
-        }
-      },
-
       ImportDefaultSpecifier(node) {
         emberImportBinding = getEmberImportBinding(node);
       },
@@ -64,14 +75,15 @@ module.exports = {
       },
 
       MemberExpression(node) {
-        if (isEmber(node.object) && isOn(node.property)) {
+        if (isEmber(node.object) && isOn(node.property) && isLifecycleHook(node.parent.arguments[0])) {
           context.report(node, MESSAGE);
         }
       },
 
       CallExpression(node) {
         if (isOn(node.callee)) {
-          if (destructedBindings.includes(node.callee.name)) {
+
+          if (isLifecycleHook(node.arguments[0]) || destructedBindings.includes(node.callee.name)) {
             context.report(node, MESSAGE);
           }
         }

--- a/tests/lib/rules/no-lifecycle-events.js
+++ b/tests/lib/rules/no-lifecycle-events.js
@@ -12,7 +12,10 @@ ruleTester.run('no-lifecycle-events', rule, {
             this.$().on('focus', () => {
               alert('sss');
             });
-          }
+          },
+          myCustomEvent: Ember.on('customEvent', function() {
+            alert('sj08');
+          })
         });`,
       parserOptions: {
         ecmaVersion: 6,


### PR DESCRIPTION
Re-enables usage of `Ember.on` for custom events, but blacklists any lifecycle hooks.

This is to support libraries/modules that define their own custom events. For example, my `ember-cli-realtime` is used as:

```
messageReceived: Ember.on('message', function() {
  // handle RT message
})
```

Legitimate use cases shouldn't throw errors.